### PR TITLE
Testing and PSFSample fixes.

### DIFF
--- a/samples/PSFSample/PSFSamplePackage/PSFSamplePackage.wapproj
+++ b/samples/PSFSample/PSFSamplePackage/PSFSamplePackage.wapproj
@@ -38,7 +38,7 @@
     <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <PackageCertificateKeyFile>Package_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>PSFSamplePackage_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
@@ -49,6 +49,7 @@
   <PropertyGroup>
     <AppxBundle>Always</AppxBundle>
     <EntryPointProjectUniqueName>..\PSF\PSF.vcxproj</EntryPointProjectUniqueName>
+    <PackageCertificateThumbprint>85E7033A5F256A5462C16A3AC0BD3AFF68564B6B</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AppxBundle>Auto</AppxBundle>
@@ -84,6 +85,7 @@
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="config.json" />
+    <None Include="PSFSamplePackage_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PSFSampleApp\PSFSampleApp.csproj" />

--- a/samples/PSFSample/PSFSamplePackage/Package.appxmanifest
+++ b/samples/PSFSample/PSFSamplePackage/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp rescap">
-  <Identity Name="PSFSampleWithFixup" Publisher="CN=Microsoft" Version="1.0.63.0" />
+  <Identity Name="PSFSampleWithFixup" Publisher="CN=microsoft" Version="1.0.66.0" />
   <Properties>
     <DisplayName>PSFSampleWithFixup</DisplayName>
     <PublisherDisplayName>Microsoft</PublisherDisplayName>

--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -48,8 +48,13 @@ function RunTest($Arch, $Config)
 
 if (!(Test-Path "$pfxPath"))
 {
-    Write-Error "$pfxPath does not exist" -RecommendedAction "Run $PSScriptRoot\scenarios\signing\CreateCert.ps1 to create it"
-    Exit -1
+	Invoke-Expression "$PSScriptRoot\scenarios\signing\CreateCert.ps1 -Install -PasswordAsPlainText CentennialFixupsTestSigning" | Out-Null
+	Write-Host "Creating test cert"
+}
+
+if(!(Test-Path "$PSScriptRoot\scenarios\Appx"))
+{
+	New-Item -ItemType Directory "$PSScriptRoot\scenarios\Appx"
 }
 
 RunTest "x64" "Debug"


### PR DESCRIPTION
This PR has two changes.
1. Adding a new cert to the PSFSample app since the current cert was expired.
2. Making testing easier by automating the directory creating and cert creating if they don't exist.