### PR TITLE
Adding SSW to the nuspec file

### DIFF
--- a/Microsoft.PackageSupportFramework.nuspec
+++ b/Microsoft.PackageSupportFramework.nuspec
@@ -29,6 +29,7 @@
     <file src="*\Release\FileRedirectionFixup*.dll" target="bin"/>
     <file src="*\Release\TraceFixup*.dll" target="bin"/>
     <file src="*\Release\WaitForDebuggerFixup*.dll" target="bin"/>
+	<file src="*\Release\StartingScriptWrapper.ps1" target="bin"/>
     <file src="readme.txt" target="" />
     <file src="AnyCPU\Release\PsfMonitor.exe" target="bin"/>
   </files>


### PR DESCRIPTION
Adding StartingScriptWrapper to the nuspec file.  This will tell the build to include the Starting Script Wrapper to the nuget package.