### PR TITLE
Getting build to work with new build system

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>

--- a/Common.props
+++ b/Common.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '16.0'">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
 
   <!-- Build with a common platform version -->

--- a/Microsoft.PackageSupportFramework.nuspec
+++ b/Microsoft.PackageSupportFramework.nuspec
@@ -31,13 +31,13 @@
     <file src="*\Release\WaitForDebuggerFixup*.dll" target="bin"/>
     <file src="x64\Release\StartingScriptWrapper.ps1" target="bin"/>
     <file src="readme.txt" target="" />
-    <file src="*\Release\PsfMonitor*.exe" target="bin"/>
-    <file src="*\Release\x86\*" target="bin"/>
-    <file src="*\Release\amd64\*" target="bin"/>
-    <file src="*\Release\Dia2Lib.dll" target="bin"/>
-    <file src="*\Release\DynamicLibraryFixup*.dll" target="bin"/>
-    <file src="*\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin"/>
-    <file src="*\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin"/>
-    <file src="*\Release\OsExtensions.dll" target="bin"/>
+    <file src="*\Release\PsfMonitor*.exe" target="bin\PsfMonitor"/>
+    <file src="*\Release\x86\*" target="bin\PsfMonitor"/>
+    <file src="*\Release\amd64\*" target="bin\PsfMonitor"/>
+    <file src="*\Release\Dia2Lib.dll" target="bin\PsfMonitor"/>
+    <file src="*\Release\DynamicLibraryFixup*.dll" target="bin\PsfMonitor"/>
+    <file src="*\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin\PsfMonitor"/>
+    <file src="*\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin\PsfMonitor"/>
+    <file src="*\Release\OsExtensions.dll" target="bin\PsfMonitor"/>
   </files>
 </package>

--- a/Microsoft.PackageSupportFramework.nuspec
+++ b/Microsoft.PackageSupportFramework.nuspec
@@ -31,6 +31,13 @@
     <file src="*\Release\WaitForDebuggerFixup*.dll" target="bin"/>
     <file src="x64\Release\StartingScriptWrapper.ps1" target="bin"/>
     <file src="readme.txt" target="" />
-    <file src="AnyCPU\Release\PsfMonitor.exe" target="bin"/>
+    <file src="*\Release\PsfMonitor*.exe" target="bin"/>
+    <file src="*\Release\x86\*" target="bin"/>
+    <file src="*\Release\amd64\*" target="bin"/>
+    <file src="*\Release\Dia2Lib.dll" target="bin"/>
+    <file src="*\Release\DynamicLibraryFixup*.dll" target="bin"/>
+    <file src="*\Release\Microsoft.Diagnostics.FastSerialization.dll" target="bin"/>
+    <file src="*\Release\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="bin"/>
+    <file src="*\Release\OsExtensions.dll" target="bin"/>
   </files>
 </package>

--- a/SignConfig.xml
+++ b/SignConfig.xml
@@ -15,8 +15,8 @@
     <file src="__INPATHROOT__\x64\Release\TraceFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\TraceFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\DynamicLibraryFixup64.dll" signType="400" dest="__OUTPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" />
-    <file src="__INPATHROOT__\Win32\Release\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitorX86.exe" />
-    <file src="__INPATHROOT__\x64\Release\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitorX64.exe" />
+    <file src="__INPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitorX86.exe" />
+    <file src="__INPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitorX64.exe" />
     <file src="__INPATHROOT__\x64\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\x64\Release\StartingScriptWrapper.ps1" />
     <file src="__INPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" />
   </job>

--- a/SignConfig.xml
+++ b/SignConfig.xml
@@ -15,8 +15,8 @@
     <file src="__INPATHROOT__\x64\Release\TraceFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\TraceFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\DynamicLibraryFixup64.dll" signType="400" dest="__OUTPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" />
-    <file src="__INPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" />
-    <file src="__INPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" />
+    <file src="__INPATHROOT__\Win32\Release\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitorX86.exe" />
+    <file src="__INPATHROOT__\x64\Release\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitorX64.exe" />
     <file src="__INPATHROOT__\x64\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\x64\Release\StartingScriptWrapper.ps1" />
     <file src="__INPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" />
   </job>

--- a/SignConfig.xml
+++ b/SignConfig.xml
@@ -14,7 +14,7 @@
     <file src="__INPATHROOT__\x64\Release\FileRedirectionFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\FileRedirectionFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\TraceFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\TraceFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" />
-    <file src="__INPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" signType="400" dest="__OUTPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" />
+    <file src="__INPATHROOT__\x64\Release\DynamicLibraryFixup64.dll" signType="400" dest="__OUTPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" />
     <file src="__INPATHROOT__\Win32\Release\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitorX86.exe" />
     <file src="__INPATHROOT__\x64\Release\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitorX64.exe" />
     <file src="__INPATHROOT__\x64\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\x64\Release\StartingScriptWrapper.ps1" />

--- a/SignConfig.xml
+++ b/SignConfig.xml
@@ -15,8 +15,8 @@
     <file src="__INPATHROOT__\x64\Release\TraceFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\TraceFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" signType="400" dest="__OUTPATHROOT__\x64\Release\WaitForDebuggerFixup64.dll" />
     <file src="__INPATHROOT__\x64\Release\DynamicLibraryFixup64.dll" signType="400" dest="__OUTPATHROOT__\Win32\Release\DynamicLibraryFixup64.dll" />
-    <file src="__INPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitorX86.exe" />
-    <file src="__INPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitorX64.exe" />
+    <file src="__INPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" signType="400" dest="__OUTPATHROOT__\Win32\Release\PsfMonitor\PsfMonitorX86.exe" />
+    <file src="__INPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" signType="400" dest="__OUTPATHROOT__\x64\Release\PsfMonitor\PsfMonitorX64.exe" />
     <file src="__INPATHROOT__\x64\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\x64\Release\StartingScriptWrapper.ps1" />
     <file src="__INPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" signType="400" dest="__OUTPATHROOT__\Win32\Release\StartingScriptWrapper.ps1" />
   </job>

--- a/fixups/DynamicLibraryFixup/DynamicLibraryFixup.vcxproj
+++ b/fixups/DynamicLibraryFixup/DynamicLibraryFixup.vcxproj
@@ -18,180 +18,11 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <VCProjectVersion>16.0</VCProjectVersion>
-    <ProjectGuid>{40F9058D-8059-4ED4-859E-7A548A73CA4F}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
-    <RootNamespace>DynamicLibraryFixup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <CharacterSet>
-    </CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>
-    </CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <CharacterSet>
-    </CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>
-    </CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <TargetName>$(ProjectName)64</TargetName>
-    <CustomBuildAfterTargets>BscMake</CustomBuildAfterTargets>
-    <CustomBuildBeforeTargets>PostBuildEvent</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <TargetName>$(ProjectName)32</TargetName>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-    <CustomBuildAfterTargets>BscMake</CustomBuildAfterTargets>
-    <CustomBuildBeforeTargets>PostBuildEvent</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <TargetName>$(ProjectName)64</TargetName>
-    <CustomBuildAfterTargets>BscMake</CustomBuildAfterTargets>
-    <CustomBuildBeforeTargets>PostBuildEvent</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <TargetName>$(ProjectName)32</TargetName>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-    <CustomBuildAfterTargets>BscMake</CustomBuildAfterTargets>
-    <CustomBuildBeforeTargets>PostBuildEvent</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_WINDOWS;_USRDLL;NDEBUG;NOGDICAPMASKS;NOVIRTUALKEYCODES;NOWINSTYLES;NOSYSMETRICS;NOMENUS;NOICONS;NOKEYSTATES;NOSYSCOMMANDS;NORASTEROPS;NOSHOWWINDOW;OEMRESOURCE;NOATOM;NOCLIPBOARD;NOCOLOR;NODRAWTEXT;NOGDI;NOKERNEL;NOMEMMGR;NOMETAFILE;NOMINMAX;NOOPENFILE;NOSCROLL;NOSERVICE;NOSOUND;NOTEXTMETRIC;NOWH;NOWINOFFSETS;NOCOMM;NOKANJI;NOHELP;NOPROFILER;NODEFERWINDOWPOS;NOMCX;WIN32_LEAN_AND_MEAN;_SCL_SECURE_NO_WARNINGS;_WINDLL;_UNICODE;UNICODE</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\..\include;$(MSBuildThisFileDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>true</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_WINDOWS;_USRDLL;WIN32;_DEBUG;NOGDICAPMASKS;NOVIRTUALKEYCODES;NOWINSTYLES;NOSYSMETRICS;NOMENUS;NOICONS;NOKEYSTATES;NOSYSCOMMANDS;NORASTEROPS;NOSHOWWINDOW;OEMRESOURCE;NOATOM;NOCLIPBOARD;NOCOLOR;NODRAWTEXT;NOGDI;NOKERNEL;NOMEMMGR;NOMETAFILE;NOMINMAX;NOOPENFILE;NOSCROLL;NOSERVICE;NOSOUND;NOTEXTMETRIC;NOWH;NOWINOFFSETS;NOCOMM;NOKANJI;NOHELP;NOPROFILER;NODEFERWINDOWPOS;NOMCX;WIN32_LEAN_AND_MEAN;_SCL_SECURE_NO_WARNINGS;_WINDLL;_UNICODE;UNICODE</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\..\include;$(MSBuildThisFileDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <MinimalRebuild>false</MinimalRebuild>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>true</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_WINDOWS;_USRDLL;_DEBUG;NOGDICAPMASKS;NOVIRTUALKEYCODES;NOWINSTYLES;NOSYSMETRICS;NOMENUS;NOICONS;NOKEYSTATES;NOSYSCOMMANDS;NORASTEROPS;NOSHOWWINDOW;OEMRESOURCE;NOATOM;NOCLIPBOARD;NOCOLOR;NODRAWTEXT;NOGDI;NOKERNEL;NOMEMMGR;NOMETAFILE;NOMINMAX;NOOPENFILE;NOSCROLL;NOSERVICE;NOSOUND;NOTEXTMETRIC;NOWH;NOWINOFFSETS;NOCOMM;NOKANJI;NOHELP;NOPROFILER;NODEFERWINDOWPOS;NOMCX;WIN32_LEAN_AND_MEAN;_SCL_SECURE_NO_WARNINGS;_WINDLL;_UNICODE;UNICODE</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\..\include;$(MSBuildThisFileDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <MinimalRebuild>false</MinimalRebuild>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>true</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_WINDOWS;_USRDLL;WIN32;NDEBUG;NOGDICAPMASKS;NOVIRTUALKEYCODES;NOWINSTYLES;NOSYSMETRICS;NOMENUS;NOICONS;NOKEYSTATES;NOSYSCOMMANDS;NORASTEROPS;NOSHOWWINDOW;OEMRESOURCE;NOATOM;NOCLIPBOARD;NOCOLOR;NODRAWTEXT;NOGDI;NOKERNEL;NOMEMMGR;NOMETAFILE;NOMINMAX;NOOPENFILE;NOSCROLL;NOSERVICE;NOSOUND;NOTEXTMETRIC;NOWH;NOWINOFFSETS;NOCOMM;NOKANJI;NOHELP;NOPROFILER;NODEFERWINDOWPOS;NOMCX;WIN32_LEAN_AND_MEAN;_SCL_SECURE_NO_WARNINGS;_WINDLL;_UNICODE;UNICODE</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\..\include;$(MSBuildThisFileDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>true</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
+    <ItemGroup>
+    <ProjectReference Include="..\..\PsfRuntime\PsfRuntime.vcxproj">
+      <Project>{87cce0ac-a7fb-4a31-89d3-c0acdb315ee0}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dll_location_spec.h" />
     <ClInclude Include="framework.h" />
@@ -203,14 +34,42 @@
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\PsfRuntime\PsfRuntime.vcxproj">
-      <Project>{87cce0ac-a7fb-4a31-89d3-c0acdb315ee0}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Xml Include="DynamicLibraryFixup.xml" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
+    <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{40F9058D-8059-4ED4-859E-7A548A73CA4F}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+    <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <SubSystem>Windows</SubSystem>
+  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\Fixups.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\Common.Build.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile />
+    <ClCompile />
+    <ClCompile>
+      <PreprocessorDefinitions>_WINDOWS;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile />
+    <ClCompile />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_WINDOWS;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
Making Dynamic Folder Fixup use build tools v141 instead of v142.

Updating signconfig and nuspec files to add all the binaries needed for PSFMonitor to their own folder.
